### PR TITLE
Remove /public prefixes from internal links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ DB_PASS=
    - editor@demo.test / Editor123!
 
 Pagina's
-- Home: `/public/index.php`
-- Wonders: `/public/wonders.php`
-- Detail: `/public/wonder.php?slug=...`
-- Map: `/public/map.php`
-- Login/Registratie: `/public/login.php`, `/public/register.php`
-- Dashboard: `/public/dashboard/index.php`
+- Home: `/index.php`
+- Wonders: `/wonders.php`
+- Detail: `/wonder.php?slug=...`
+- Map: `/map.php`
+- Login/Registratie: `/login.php`, `/register.php`
+- Dashboard: `/dashboard/index.php`
 
 Beveiliging
 - PDO prepared statements, utf8mb4

--- a/app/controllers/MediaController.php
+++ b/app/controllers/MediaController.php
@@ -16,11 +16,12 @@ class MediaController
 		$wonderId = (int)($_POST['wonder_id'] ?? 0);
 		$ext = pathinfo($f['name'], PATHINFO_EXTENSION) ?: 'bin';
 		$slug = $_POST['slug'] ?? ('wonder-' . $wonderId);
-		$destDir = __DIR__ . '/../../public/assets/img/wonders';
-		@mkdir($destDir, 0777, true);
-		$destRel = '/public/assets/img/wonders/' . $slug . '-' . time() . '.' . $ext;
-		$destAbs = __DIR__ . '/../../' . ltrim($destRel, '/');
-		if (!move_uploaded_file($f['tmp_name'], $destAbs)) return 'Kon bestand niet opslaan';
+                $destDir = __DIR__ . '/../../public/assets/img/wonders';
+                @mkdir($destDir, 0777, true);
+                $filename = $slug . '-' . time() . '.' . $ext;
+                $destRel = '/assets/img/wonders/' . $filename;
+                $destAbs = $destDir . '/' . $filename;
+                if (!move_uploaded_file($f['tmp_name'], $destAbs)) return 'Kon bestand niet opslaan';
 		$pdo = get_pdo();
 		$stmt = $pdo->prepare('INSERT INTO media(wonder_id,type,url,mime,size,status,created_by) VALUES(?,?,?,?,?,"pending",?)');
 		$stmt->execute([$wonderId, (strpos($f['type'],'image')===0?'image':'document'), $destRel, $f['type'], (int)$f['size'], current_user()['id'] ?? null]);

--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -14,7 +14,7 @@ class UserController
 		sleep(1);
 		if (auth_login($email, $pass)) {
 			self::audit('login', ['email' => $email]);
-			redirect('/public/dashboard/index.php');
+                        redirect('/dashboard/index.php');
 		}
 		return 'Onjuiste login';
 	}
@@ -42,7 +42,7 @@ class UserController
 		$role = $_POST['role'] ?? 'visitor';
 		User::updateRole($id, $role);
 		self::audit('role_update', ['user_id' => $id, 'role' => $role]);
-		redirect('/public/dashboard/users.php');
+                redirect('/dashboard/users.php');
 	}
 
 	private static function audit(string $action, array $changes): void {

--- a/app/lib/auth.php
+++ b/app/lib/auth.php
@@ -44,9 +44,9 @@ function auth_logout(): void {
 }
 
 function require_auth(): void {
-	if (!current_user()) {
-		redirect('/public/login.php');
-	}
+        if (!current_user()) {
+                redirect('/login.php');
+        }
 }
 
 function require_role_or_redirect(array $roles): void {

--- a/database/seed.sql
+++ b/database/seed.sql
@@ -35,7 +35,7 @@
 
 	-- Media (one image each placeholder)
 	INSERT INTO media (wonder_id, type, url, mime, size, status, created_by)
-	SELECT id, 'image', CONCAT('/public/assets/img/wonders/', slug, '.jpg'), 'image/jpeg', 12345, 'approved', 1 FROM wonders;
+        SELECT id, 'image', CONCAT('/assets/img/wonders/', slug, '.jpg'), 'image/jpeg', 12345, 'approved', 1 FROM wonders;
 
 	-- Basic tag assignments
 	INSERT INTO wonder_tags (wonder_id, tag_id, added_by)

--- a/public/dashboard/index.php
+++ b/public/dashboard/index.php
@@ -14,10 +14,10 @@ $user = current_user();
 		<div class="card"><div class="content"><h3>Statistiek</h3><p class="sub">Kleine tellingen</p></div></div>
 	</div>
 	<nav class="chips" style="margin-top:16px">
-		<?php if (is_role('researcher')): ?><a class="btn" href="/public/dashboard/wonders.php">Mijn wonderen</a><?php endif; ?>
-		<?php if (is_role('editor') || is_role('admin')): ?><a class="btn" href="/public/dashboard/review_queue.php">Review queue</a><?php endif; ?>
-		<?php if (is_role('archivist') || is_role('admin')): ?><span class="btn" aria-disabled="true">Historiek & GPS</span><?php endif; ?>
-		<?php if (is_role('admin')): ?><a class="btn" href="/public/dashboard/users.php">Users</a><?php endif; ?>
+                <?php if (is_role('researcher')): ?><a class="btn" href="/dashboard/wonders.php">Mijn wonderen</a><?php endif; ?>
+                <?php if (is_role('editor') || is_role('admin')): ?><a class="btn" href="/dashboard/review_queue.php">Review queue</a><?php endif; ?>
+                <?php if (is_role('archivist') || is_role('admin')): ?><span class="btn" aria-disabled="true">Historiek & GPS</span><?php endif; ?>
+                <?php if (is_role('admin')): ?><a class="btn" href="/dashboard/users.php">Users</a><?php endif; ?>
 	</nav>
 </main>
 <?php include __DIR__ . '/../partials/footer.php'; ?>

--- a/public/dashboard/wonders.php
+++ b/public/dashboard/wonders.php
@@ -11,7 +11,7 @@ $items = $data['items'];
 <?php include __DIR__ . '/../partials/nav.php'; ?>
 <main class="container">
 	<h1>Mijn wonderen</h1>
-	<a class="btn" href="/public/dashboard/wonder_new.php">Nieuw wonder</a>
+        <a class="btn" href="/dashboard/wonder_new.php">Nieuw wonder</a>
 	<table class="table" aria-label="Mijn records" style="margin-top:12px">
 		<thead><tr><th>Titel</th><th>Status</th><th>Continent</th><th>Categorie</th><th>Acties</th></tr></thead>
 		<tbody>
@@ -26,7 +26,7 @@ $items = $data['items'];
 				<td><?php echo e($w['continent']); ?></td>
 				<td><?php echo e($w['category']); ?></td>
 				<td>
-					<a class="btn" href="/public/dashboard/wonder_edit.php?id=<?php echo (int)$w['id']; ?>">Bewerken</a>
+                                        <a class="btn" href="/dashboard/wonder_edit.php?id=<?php echo (int)$w['id']; ?>">Bewerken</a>
 				</td>
 			</tr>
 			<?php endforeach; ?>

--- a/public/index.php
+++ b/public/index.php
@@ -11,19 +11,19 @@ $counts = Wonder::countsByContinent();
 	<section class="hero" aria-label="Zoek">
 		<h1>Codex Mundi</h1>
 		<p class="sub">Digitaal archief van 21 wereldwonderen</p>
-		<form action="/public/wonders.php" method="get" style="margin-top:16px">
+                <form action="/wonders.php" method="get" style="margin-top:16px">
 			<div class="searchbar" role="search">
 				<svg width="18" height="18" aria-hidden="true" viewBox="0 0 24 24" fill="none"><path d="M21 21l-4.35-4.35" stroke="#6ea8fe" stroke-width="2"/><circle cx="11" cy="11" r="7" stroke="#6ea8fe" stroke-width="2"/></svg>
 				<input id="search" name="q" placeholder="Zoek wereldwonder, land of mythe..." aria-label="Zoek" />
 			</div>
 		</form>
 		<div class="chips" style="margin-top:12px">
-			<a class="chip" href="/public/wonders.php?continent=africa">Africa (<?php echo $counts['africa']??0; ?>)</a>
-			<a class="chip" href="/public/wonders.php?continent=asia">Asia (<?php echo $counts['asia']??0; ?>)</a>
-			<a class="chip" href="/public/wonders.php?continent=europe">Europe (<?php echo $counts['europe']??0; ?>)</a>
-			<a class="chip" href="/public/wonders.php?continent=north_america">N. America (<?php echo $counts['north_america']??0; ?>)</a>
-			<a class="chip" href="/public/wonders.php?continent=south_america">S. America (<?php echo $counts['south_america']??0; ?>)</a>
-			<a class="chip" href="/public/wonders.php?continent=oceania">Oceania (<?php echo $counts['oceania']??0; ?>)</a>
+                        <a class="chip" href="/wonders.php?continent=africa">Africa (<?php echo $counts['africa']??0; ?>)</a>
+                        <a class="chip" href="/wonders.php?continent=asia">Asia (<?php echo $counts['asia']??0; ?>)</a>
+                        <a class="chip" href="/wonders.php?continent=europe">Europe (<?php echo $counts['europe']??0; ?>)</a>
+                        <a class="chip" href="/wonders.php?continent=north_america">N. America (<?php echo $counts['north_america']??0; ?>)</a>
+                        <a class="chip" href="/wonders.php?continent=south_america">S. America (<?php echo $counts['south_america']??0; ?>)</a>
+                        <a class="chip" href="/wonders.php?continent=oceania">Oceania (<?php echo $counts['oceania']??0; ?>)</a>
 		</div>
 	</section>
 	<section style="margin:24px 0">
@@ -31,13 +31,13 @@ $counts = Wonder::countsByContinent();
 		<div class="grid grid-3">
 			<?php foreach ($featured as $w): ?>
 				<article class="card">
-					<a href="/public/wonder.php?slug=<?php echo e($w['slug']); ?>">
-						<img class="card-cover" src="/public/assets/img/wonders/<?php echo e($w['slug']); ?>.jpg" alt="<?php echo e($w['title']); ?>" />
+                                        <a href="/wonder.php?slug=<?php echo e($w['slug']); ?>">
+                                                <img class="card-cover" src="/assets/img/wonders/<?php echo e($w['slug']); ?>.jpg" alt="<?php echo e($w['title']); ?>" />
 					</a>
 					<div class="content">
 						<h3><?php echo e($w['title']); ?></h3>
 						<p class="sub"><?php echo e(ucfirst($w['continent'])); ?> • <?php echo e($w['country']); ?></p>
-						<a class="btn" href="/public/wonder.php?slug=<?php echo e($w['slug']); ?>">Bekijken</a>
+                                                <a class="btn" href="/wonder.php?slug=<?php echo e($w['slug']); ?>">Bekijken</a>
 					</div>
 				</article>
 			<?php endforeach; ?>

--- a/public/logout.php
+++ b/public/logout.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../app/lib/auth.php';
 auth_logout();
-header('Location: /public/index.php');
+header('Location: /index.php');
 exit;
 
 

--- a/public/map.php
+++ b/public/map.php
@@ -14,12 +14,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 	const map = L.map('map').setView([20, 0], 2);
 	L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 19}).addTo(map);
 	try{
-		const res = await fetch('/public/map_points.php');
+                const res = await fetch('/map_points.php');
 		const points = await res.json();
 		points.forEach(p=>{
 			if(!p.lat || !p.lng) return;
 			const m = L.marker([p.lat, p.lng]);
-			m.bindPopup(`<a href="/public/wonder.php?slug=${p.slug}">${p.title}</a>`);
+                        m.bindPopup(`<a href="/wonder.php?slug=${p.slug}">${p.title}</a>`);
 			m.addTo(map);
 		});
 	}catch(e){ console.error(e); }

--- a/public/partials/header.php
+++ b/public/partials/header.php
@@ -7,7 +7,7 @@
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@500;700&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="/public/assets/css/main.css">
-	<script defer src="/public/assets/js/main.js"></script>
+        <link rel="stylesheet" href="/assets/css/main.css">
+        <script defer src="/assets/js/main.js"></script>
 </head>
 <body>

--- a/public/partials/nav.php
+++ b/public/partials/nav.php
@@ -1,18 +1,18 @@
 
 <header class="site-header">
 	<div class="container header-inner">
-		<a class="logo" href="/public/index.php">Codex Mundi</a>
-		<nav class="main-nav" aria-label="Hoofdnavigatie">
-			<a data-nav="/public/index.php" href="/public/index.php">Home</a>
-			<a data-nav="/public/wonders.php" href="/public/wonders.php">Wonders</a>
-			<a data-nav="/public/map.php" href="/public/map.php">Map</a>
-			<?php if (current_user()): ?>
-				<a data-nav="/public/dashboard/index.php" href="/public/dashboard/index.php">Account</a>
-				<a href="/public/logout.php" class="sub">Logout</a>
-			<?php else: ?>
-				<a data-nav="/public/login.php" href="/public/login.php">Login</a>
-				<a data-nav="/public/register.php" href="/public/register.php" class="sub">Register</a>
-			<?php endif; ?>
-		</nav>
+                <a class="logo" href="/index.php">Codex Mundi</a>
+                <nav class="main-nav" aria-label="Hoofdnavigatie">
+                        <a data-nav="/index.php" href="/index.php">Home</a>
+                        <a data-nav="/wonders.php" href="/wonders.php">Wonders</a>
+                        <a data-nav="/map.php" href="/map.php">Map</a>
+                        <?php if (current_user()): ?>
+                                <a data-nav="/dashboard/index.php" href="/dashboard/index.php">Account</a>
+                                <a href="/logout.php" class="sub">Logout</a>
+                        <?php else: ?>
+                                <a data-nav="/login.php" href="/login.php">Login</a>
+                                <a data-nav="/register.php" href="/register.php" class="sub">Register</a>
+                        <?php endif; ?>
+                </nav>
 	</div>
 </header>

--- a/public/wonder.php
+++ b/public/wonder.php
@@ -12,7 +12,7 @@ $related = $data['related'];
 <?php include __DIR__ . '/partials/nav.php'; ?>
 <main class="container">
 	<figure class="card" style="overflow:hidden">
-		<img class="card-cover" src="/public/assets/img/wonders/<?php echo e($w['slug']); ?>.jpg" alt="<?php echo e($w['title']); ?> headerbeeld" />
+                <img class="card-cover" src="/assets/img/wonders/<?php echo e($w['slug']); ?>.jpg" alt="<?php echo e($w['title']); ?> headerbeeld" />
 	</figure>
 	<header style="margin:16px 0">
 		<h1><?php echo e($w['title']); ?></h1>
@@ -54,9 +54,9 @@ $related = $data['related'];
 		<h3>Gerelateerde wonderen</h3>
 		<div class="grid grid-3">
 			<?php foreach ($related as $r): ?>
-				<article class="card">
-					<a href="/public/wonder.php?slug=<?php echo e($r['slug']); ?>">
-						<img class="card-cover" src="/public/assets/img/wonders/<?php echo e($r['slug']); ?>.jpg" alt="<?php echo e($r['title']); ?>" />
+                                <article class="card">
+                                        <a href="/wonder.php?slug=<?php echo e($r['slug']); ?>">
+                                                <img class="card-cover" src="/assets/img/wonders/<?php echo e($r['slug']); ?>.jpg" alt="<?php echo e($r['title']); ?>" />
 					</a>
 					<div class="content"><h4><?php echo e($r['title']); ?></h4></div>
 				</article>

--- a/public/wonders.php
+++ b/public/wonders.php
@@ -61,8 +61,8 @@ $pages = max(1, (int)ceil($total / $limit));
 			<div id="wonder-list" class="grid grid-3 card-list" aria-live="polite">
 				<?php foreach ($items as $w): ?>
 					<article class="card" data-title="<?php echo e($w['title']); ?>" data-category="<?php echo e($w['category']); ?>" data-continent="<?php echo e($w['continent']); ?>" data-year="<?php echo (int)$w['year_built']; ?>" data-exists="<?php echo (int)$w['exists_now']; ?>">
-						<a href="/public/wonder.php?slug=<?php echo e($w['slug']); ?>" aria-label="Bekijk <?php echo e($w['title']); ?>">
-							<img class="card-cover" src="/public/assets/img/wonders/<?php echo e($w['slug']); ?>.jpg" alt="<?php echo e($w['title']); ?>" />
+                                        <a href="/wonder.php?slug=<?php echo e($w['slug']); ?>" aria-label="Bekijk <?php echo e($w['title']); ?>">
+                                                <img class="card-cover" src="/assets/img/wonders/<?php echo e($w['slug']); ?>.jpg" alt="<?php echo e($w['title']); ?>" />
 						</a>
 						<div class="content">
 							<h3><?php echo e($w['title']); ?></h3>
@@ -71,7 +71,7 @@ $pages = max(1, (int)ceil($total / $limit));
 								<span class="chip"><?php echo e($w['category']); ?></span>
 								<span class="badge <?php echo $w['exists_now']?'green':'red'; ?>"><?php echo $w['exists_now']?'Bestaat nog':'Bestaat niet'; ?></span>
 							</div>
-							<a class="btn" href="/public/wonder.php?slug=<?php echo e($w['slug']); ?>">Bekijken</a>
+                                                        <a class="btn" href="/wonder.php?slug=<?php echo e($w['slug']); ?>">Bekijken</a>
 						</div>
 					</article>
 				<?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Use root-relative paths for assets and navigation links
- Update redirects and controllers to new paths
- Adjust seed data and README documentation

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`


